### PR TITLE
New sensor types for IoT Pilot

### DIFF
--- a/ontology/yaml/resources/HVAC/entity_types/SENSOR.yaml
+++ b/ontology/yaml/resources/HVAC/entity_types/SENSOR.yaml
@@ -68,3 +68,32 @@ SENSOR_CO2M:
   implements:
     - /SENSOR # Inherits from global namespace
     - CO2M
+
+SENSOR_LA3A:
+  description: "Three-axis linear acceleration (vibration) sensor with optional temperature and battery monitoring."
+  is_canonical: true
+  implements:
+    - /SENSOR # Inherits from global namespace
+  opt_uses:
+    - local_air_temperature_sensor
+    - battery_charge_percentage_sensor
+  uses:
+    - fivesecondrolling_max_xaxis_linearacceleration_sensor
+    - fivesecondrolling_max_yaxis_linearacceleration_sensor
+    - fivesecondrolling_max_zaxis_linearacceleration_sensor
+    - fivesecondrolling_min_xaxis_linearacceleration_sensor
+    - fivesecondrolling_min_yaxis_linearacceleration_sensor
+    - fivesecondrolling_min_zaxis_linearacceleration_sensor
+    - fivesecondrolling_rootmeansquare_xaxis_linearacceleration_sensor
+    - fivesecondrolling_rootmeansquare_yaxis_linearacceleration_sensor
+    - fivesecondrolling_rootmeansquare_zaxis_linearacceleration_sensor
+
+SENSOR_FDPM:
+  description: "Filter differential pressure sensor with optional temperature monitoring."
+  is_canonical: true
+  implements:
+    - /SENSOR # Inherits from global namespace
+  opt_uses:
+    - local_air_temperature_sensor
+  uses:
+    - filter_differential_pressure_sensor


### PR DESCRIPTION
New types for NCD vibration and DP sensors.

Vendor documentation for reference:
https://store.ncd.io/product/industrial-wireless-vibration-and-temperature-sensor/
https://ncd.io/wireless-bidirectional-differential-pressure-sensor-product-manual/